### PR TITLE
Add tls secret value for blockscout stack

### DIFF
--- a/charts/blockscout-stack/templates/blockscout-ingress.yaml
+++ b/charts/blockscout-stack/templates/blockscout-ingress.yaml
@@ -31,7 +31,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.blockscout.ingress.hostname | quote }}
-      secretName: {{ $fullName }}-blockscout-tls
+      secretName: {{ .Values.blockscout.ingress.tls.secretName | default (printf "%s-blockscout-tls" $fullName) }}
   {{- end }}
   rules:
     - host: {{ .Values.blockscout.ingress.hostname | quote }}

--- a/charts/blockscout-stack/templates/frontend-ingress.yaml
+++ b/charts/blockscout-stack/templates/frontend-ingress.yaml
@@ -31,7 +31,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.frontend.ingress.hostname | quote }}
-      secretName: {{ $fullName }}-frontend-tls
+      secretName: {{ .Values.blockscout.ingress.tls.secretName | default (printf "%s-frontend-tls" $fullName) }}
   {{- end }}
   rules:
     - host: {{ .Values.frontend.ingress.hostname | quote }}

--- a/charts/blockscout-stack/templates/stats-ingress.yaml
+++ b/charts/blockscout-stack/templates/stats-ingress.yaml
@@ -31,7 +31,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.stats.ingress.hostname | quote }}
-      secretName: {{ $fullName }}-stats-tls
+      secretName: {{ .Values.blockscout.ingress.tls.secretName | default (printf "%s-stats-tls" $fullName) }}
   {{- end }}
   rules:
     - host: {{ .Values.stats.ingress.hostname | quote }}


### PR DESCRIPTION
This PR allows for the TLS secretName to be specified via input values. This a backwards compatible change as if no secretName is provided it defaults to the old value.