### PR TITLE
[blockscout-stack] Do not use envFromSecret when not defined (#18)

### DIFF
--- a/charts/blockscout-stack/CHANGELOG.md
+++ b/charts/blockscout-stack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 1.5.1
+
+### Fixes
+
+- Do not refer to `envFromSecret` when not defined for backend/frontend
+
 ## 1.5.0
 
 ### Feature

--- a/charts/blockscout-stack/Chart.yaml
+++ b/charts/blockscout-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout-stack/templates/blockscout-deployment.yaml
+++ b/charts/blockscout-stack/templates/blockscout-deployment.yaml
@@ -77,8 +77,10 @@ spec:
           {{- end }}
           {{- if or .Values.blockscout.envFromSecret .Values.blockscout.envFrom }}
           envFrom:
+          {{- if .Values.blockscout.envFromSecret }}
           - secretRef:
               name: {{ include "blockscout-stack.fullname" . }}-blockscout-env
+          {{- end }}
           {{- range .Values.blockscout.envFrom }}
           - {{ toYaml . | nindent 12 | trim }}
           {{- end }}
@@ -138,8 +140,10 @@ spec:
           {{- end }}
           {{- if or .Values.blockscout.envFromSecret .Values.blockscout.envFrom }}
           envFrom:
+          {{- if .Values.blockscout.envFromSecret }}
           - secretRef:
               name: {{ include "blockscout-stack.fullname" . }}-blockscout-env
+          {{- end }}
           {{- range .Values.blockscout.envFrom }}
           - {{ toYaml . | nindent 12 | trim }}
           {{- end }}

--- a/charts/blockscout-stack/templates/frontend-deployment.yaml
+++ b/charts/blockscout-stack/templates/frontend-deployment.yaml
@@ -89,8 +89,10 @@ spec:
           {{- end }}
           {{- if or .Values.frontend.envFromSecret .Values.frontend.envFrom }}
           envFrom:
+          {{- if .Values.frontend.envFromSecret }}
           - secretRef:
               name: {{ include "blockscout-stack.fullname" . }}-frontend-env
+          {{- end }}
           {{- range .Values.frontend.envFrom }}
           - {{ toYaml . | nindent 12 | trim }}
           {{- end }}


### PR DESCRIPTION
This is a quick fix for the #19 and related to #18. It contains the following changes
- Do not use `secretRef` for `envFromSecret` when it is not defined for backend
- Do not use `secretRef` for `envFromSecret` when it is not defined for frontend
- Updated chart version
- Updated changelog

Chart was tested manually
```yaml
helm install test-release \
  --dry-run=server \
  ./charts/blockscout-stack \
  -n test-namespace \
  --set config.prometheus.enabled=false --values values.yaml
```
[`values.yaml`](https://github.com/blockscout/helm-charts/blob/main/charts/blockscout-stack/values.yaml)
```yaml
blockscout:
  envFromSecret: []
  #  NAME: VALUE
  envFrom:
    - secretRef:
        name: blockscout-backend-data
```

previous version diff
```diff
-          envFrom:
-          - secretRef:
-              name: test-release-blockscout-stack-blockscout-env
-          - secretRef:
-              name: blockscout-backend-data
+          envFrom:
+          - secretRef:
+              name: blockscout-backend-data
```
