### PR TITLE
Add extraEnv to userOpsIndexer and stats services

### DIFF
--- a/charts/blockscout-stack/templates/stats-deployment.yaml
+++ b/charts/blockscout-stack/templates/stats-deployment.yaml
@@ -53,6 +53,9 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- range .Values.stats.extraEnv }}
+          - {{ toYaml . | nindent 12 | trim }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "blockscout-stack.fullname" . }}-stats-env

--- a/charts/blockscout-stack/templates/user-ops-indexer-deployment.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-deployment.yaml
@@ -68,6 +68,9 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- range .Values.userOpsIndexer.extraEnv }}
+          - {{ toYaml . | nindent 12 | trim }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer-env

--- a/charts/blockscout-stack/values.yaml
+++ b/charts/blockscout-stack/values.yaml
@@ -260,7 +260,7 @@ stats:
     tag: latest
     pullPolicy: IfNotPresent
 
-  replicasCount: 1
+  replicaCount: 1
   service:
     type: ClusterIP
     port: 80
@@ -327,6 +327,12 @@ stats:
     # NAME: VALUE
   envFromSecret: []
     # NAME: VALUE
+  extraEnv: []
+    # - name: STATS__DB_URL
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: blockscout-stats-secret
+    #       key: STATS__DB_URL
 
 userOpsIndexer:
   enabled: false
@@ -337,7 +343,7 @@ userOpsIndexer:
     tag: latest
     pullPolicy: IfNotPresent
 
-  replicasCount: 1
+  replicaCount: 1
   service:
     type: ClusterIP
     port: 80
@@ -399,6 +405,12 @@ userOpsIndexer:
     # NAME: VALUE
   envFromSecret: []
     # NAME: VALUE
+  extraEnv: []
+    # - name: USER_OPS_INDEXER__DATABASE__CONNECT__URL
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: blockscout-userops-indexer-secret
+    #       key: USER_OPS_INDEXER__DATABASE__CONNECT__URL
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Fixed a typo in `stats` and `userOpsIndexer`, where `replicaCount` was named `replicasCount` and was thus marked as undefined.

Also added an `extraEnv` field to both `stats` and `userOpsIndexer`

Here's an example of it working.

## Input:
Ran with the following command: `helm template ./ --generate-name --debug --dry-run -f ./my.values.yaml`

```yaml
  serviceAccount:
    create: false
  config:
    prometheus:
      enabled: false
  blockscout:
    enabled: false
  frontend:
    enabled: false
  stats:
    enabled: true
    replicaCount: 5
    extraEnv:
      - name: STATS__DB_URL
        valueFrom:
          secretKeyRef:
            name: blockscout-credentials
            key: STATS__DB_URL
    ingress:
      enabled: false
  userOpsIndexer:
    enabled: true
    replicaCount: 6
    extraEnv:
      - name: USER_OPS_INDEXER__DATABASE__CONNECT__URL
        valueFrom:
          secretKeyRef:
            name: blockscout-credentials
            key: DATABASE_URL
    ingress:
      enabled: false
```

## Output:

```yaml
---
# Source: blockscout-stack/templates/stats-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: release-name-blockscout-stack-stats-env
  labels:
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
---
# Source: blockscout-stack/templates/user-ops-indexer-secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: release-name-blockscout-stack-user-ops-indexer-env
  labels:
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
---
# Source: blockscout-stack/templates/stats-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-blockscout-stack-stats-svc
  labels:
    app: release-name-stats-svc
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - port: 6060
      targetPort: http-metrics
      protocol: TCP
      name: http-metrics
  selector:
    app: release-name-stats
---
# Source: blockscout-stack/templates/user-ops-indexer-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-blockscout-stack-user-ops-indexer-svc
  labels:
    app: release-name-user-ops-indexer-svc
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - port: 6060
      targetPort: http-metrics
      protocol: TCP
      name: http-metrics
  selector:
    app: release-name-user-ops-indexer
---
# Source: blockscout-stack/templates/user-ops-indexer-service.yaml
kind: Service
apiVersion: v1
metadata:
  name: release-name-blockscout-stack-user-ops-indexer-grpc-svc
  labels:
    app: release-name-user-ops-indexer-svc
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 8051
      targetPort: grpc
      protocol: TCP
      name: grpc
  selector:
    app: release-name-user-ops-indexer
---
# Source: blockscout-stack/templates/stats-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-blockscout-stack-stats
  labels:
    app: release-name-stats
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 5
  selector:
    matchLabels:
      app: release-name-stats
  template:
    metadata:
      annotations:
        checksum/config: 687cb426e75ee0fc14f982d4f41632216b40e9f787df403bb6bd08e394547e3a
      labels:
        app: release-name-stats
        app.kubernetes.io/name: blockscout-stack
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: default
      securityContext:
        {}
      containers:
        - name: blockscout-stack-stats
          securityContext:
            {}
          image: "ghcr.io/blockscout/stats:latest"
          resources:
            limits:
              cpu: 250m
              memory: 512Mi
            requests:
              cpu: 250m
              memory: 512Mi
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8050
              protocol: TCP
            - name: http-metrics
              containerPort: 6060
              protocol: TCP
          env:
          - name: STATS_CHARTS__TEMPLATE_VALUES__NATIVE_COIN_SYMBOL
            value: "ETH"
          - name: STATS__DB_URL
            valueFrom:
              secretKeyRef:
                key: STATS__DB_URL
                name: blockscout-credentials
          envFrom:
            - secretRef:
                name: release-name-blockscout-stack-stats-env
---
# Source: blockscout-stack/templates/user-ops-indexer-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-blockscout-stack-user-ops-indexer
  labels:
    app: release-name-user-ops-indexer
    helm.sh/chart: blockscout-stack-1.6.2
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "6.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 6
  selector:
    matchLabels:
      app: release-name-user-ops-indexer
  template:
    metadata:
      annotations:
        checksum/config: cd1fcabef31558036294faac8689d0ed2544183412566395997afbd916a8e7a7
      labels:
        app: release-name-user-ops-indexer
        app.kubernetes.io/name: blockscout-stack
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: default
      securityContext:
        {}
      containers:
        - name: blockscout-stack-user-ops-indexer
          securityContext:
            {}
          image: "ghcr.io/blockscout/user-ops-indexer:latest"
          resources:
            limits:
              cpu: 250m
              memory: 512Mi
            requests:
              cpu: 250m
              memory: 512Mi
          imagePullPolicy: IfNotPresent
          ports:
            - name: http
              containerPort: 8050
              protocol: TCP
            - name: grpc
              containerPort: 8051
              protocol: TCP
            - name: http-metrics
              containerPort: 6060
              protocol: TCP
          env:
          - name: USER_OPS_INDEXER__SERVER__HTTP__ENABLED
            value: 'true'
          - name: USER_OPS_INDEXER__SERVER__HTTP__ADDR
            value: '0.0.0.0:8050'
          - name: USER_OPS_INDEXER__SERVER__GRPC__ENABLED
            value: "true"
          - name: USER_OPS_INDEXER__SERVER__GRPC__ADDR
            value: '0.0.0.0:8051'
          - name: USER_OPS_INDEXER__METRICS__ENABLED
            value: 'true'
          - name: USER_OPS_INDEXER__METRICS__ADDR
            value: '0.0.0.0:6060'
          - name: USER_OPS_INDEXER__METRICS__ROUTE
            value: '/metrics'
          - name: USER_OPS_INDEXER__DATABASE__CONNECT__URL
            valueFrom:
              secretKeyRef:
                key: DATABASE_URL
                name: blockscout-credentials
          envFrom:
            - secretRef:
                name: release-name-blockscout-stack-user-ops-indexer-env
```