### PR TITLE
Add MODE env variable to distinguish indexer and api applications

### DIFF
--- a/charts/blockscout-stack/CHANGELOG.md
+++ b/charts/blockscout-stack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 1.6.4
+
+### Feature
+
+- Adding MODE env variable for backend to distinguish API/indexer applications.
+
 ## 1.6.3
 
 ### Feature

--- a/charts/blockscout-stack/Chart.yaml
+++ b/charts/blockscout-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.3
+version: 1.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout-stack/templates/blockscout-deployment.yaml
+++ b/charts/blockscout-stack/templates/blockscout-deployment.yaml
@@ -117,6 +117,13 @@ spec:
               containerPort: 4000
               protocol: TCP
           env:
+          {{- if .Values.blockscout.separateApi.enabled }}
+          - name: MODE
+            value: "api"
+          {{- else }}
+          - name: MODE
+            value: "all"
+          {{- end }}
           - name: PORT
             value: "4000"
           - name: CHAIN_ID
@@ -264,6 +271,8 @@ spec:
               containerPort: 4000
               protocol: TCP
           env:
+          - name: MODE
+          - value: "indexer"
           - name: PORT
             value: "4000"
           - name: CHAIN_ID


### PR DESCRIPTION
Starting from Blockscout backend release 6.8.0, a new variable "MODE" is introduced to distinguish "api" and "indexer" applications. It accepts three values:
- "all"
- "indexer"
- "api"