### PR TITLE
fix: Add security context to init container and migration job

### DIFF
--- a/charts/blockscout-stack/templates/blockscout-deployment.yaml
+++ b/charts/blockscout-stack/templates/blockscout-deployment.yaml
@@ -36,6 +36,8 @@ spec:
       {{- if and .Values.blockscout.init.enabled (not .Values.blockscout.separateApi.enabled) }}
       initContainers:
         - name: init-migrations
+          securityContext:
+            {{- toYaml .Values.blockscout.securityContext | nindent 12 }}
           image: "{{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}"
           resources:
             {{- toYaml .Values.blockscout.resources | nindent 12 }}

--- a/charts/blockscout-stack/templates/blockscout-migration-job.yaml
+++ b/charts/blockscout-stack/templates/blockscout-migration-job.yaml
@@ -14,6 +14,8 @@ spec:
     spec:
       containers:
         - name: blockscout-migrations
+          securityContext:
+            {{- toYaml .Values.blockscout.securityContext | nindent 12 }}
           image: "{{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}"
           imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}
           {{- with .Values.blockscout.init.command }}


### PR DESCRIPTION
## What
* Add security context in the init container and migration job, so they can run with the same settings as app container

## Why
* Security Context was added in the main app container but was missing in the init container and migration job