### PR TITLE
[blockscout-stack] Add imagePullSecrets to blockscout-migration-job

### DIFF
--- a/charts/blockscout-stack/templates/blockscout-migration-job.yaml
+++ b/charts/blockscout-stack/templates/blockscout-migration-job.yaml
@@ -14,6 +14,10 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.blockscout.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: blockscout-migrations
           image: "{{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}"


### PR DESCRIPTION
Fixing [issue#61](https://github.com/blockscout/helm-charts/issues/61) previously I mentioned.

Adds imagePullSecrets to migration job which does not use pull secrets currently