### PR TITLE
Fix missed podAnnotations for stats service deployment

### DIFF
--- a/charts/blockscout-stack/Chart.yaml
+++ b/charts/blockscout-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout-stack/templates/stats-deployment.yaml
+++ b/charts/blockscout-stack/templates/stats-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       {{- if eq .Values.stats.image.pullPolicy "Always" }}
         releaseTime: {{ dateInZone "2006-01-02 15:04:05Z" (now) "UTC"| quote }}
       {{- end }}
+      {{- with .Values.stats.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ include "blockscout-stack.fullname" . }}-stats
         {{- include "blockscout-stack.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
There are missing podAnnotations for stats service deployment, in my use case i can not use vault agent injector as it is requires pod level annotations to create init container