### PR TITLE
fix: Set `STATS__BLOCKSCOUT_API_URL` only if ingress exists

### DIFF
--- a/charts/blockscout-stack/templates/stats-deployment.yaml
+++ b/charts/blockscout-stack/templates/stats-deployment.yaml
@@ -52,8 +52,10 @@ spec:
               containerPort: 6060
               protocol: TCP
           env:
+          {{- if .Values.blockscout.ingress.hostname }}
           - name: STATS__BLOCKSCOUT_API_URL
             value: "https://{{ .Values.blockscout.ingress.hostname }}"
+          {{- end }}
           {{- if .Values.config.network.currency.symbol }}
           - name: STATS_CHARTS__TEMPLATE_VALUES__NATIVE_COIN_SYMBOL
             value: {{ .Values.config.network.currency.symbol | quote }}


### PR DESCRIPTION
This allows to override `STATS__BLOCKSCOUT_API_URL` if ingress isn't used or URL without SSL/TLS is needed.