### PR TITLE
feat(blockscout-stack): add commonLabels support

### DIFF
--- a/charts/blockscout-stack/CHANGELOG.md
+++ b/charts/blockscout-stack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 3.5.0
+
+### Feature
+
+- Add support for commonLabels to apply custom labels to all resources
+
 ## 3.4.2
 
 ### Fix

--- a/charts/blockscout-stack/Chart.yaml
+++ b/charts/blockscout-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.2
+version: 3.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout-stack/templates/_helpers.tpl
+++ b/charts/blockscout-stack/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "blockscout-stack.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/blockscout-stack/values.yaml
+++ b/charts/blockscout-stack/values.yaml
@@ -8,6 +8,9 @@ nameOverride: ""
 ## Provide a name to substitute for the full names of resources
 ##
 fullnameOverride: ""
+## Common labels to add to all resources
+##
+commonLabels: {}
 ## Reference to one or more secrets to be used when pulling images
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 ##


### PR DESCRIPTION

## What 

- Add ability to pass custom labels to all resources via commonLabels value.
- Bump chart version to 3.5.0.