### PR TITLE
fix(blockscout-stack): alert name for prometheus rule cannot be templated

### DIFF
--- a/charts/blockscout-stack/templates/blockscout-prometheus-rules.yaml
+++ b/charts/blockscout-stack/templates/blockscout-prometheus-rules.yaml
@@ -9,7 +9,7 @@ spec:
   groups:
     - name: {{ include "blockscout-stack.fullname" . }}-blockscout
       rules:
-      - alert: "{{`{{ $labels.job }}`}} has no new batches"
+      - alert: BlockscoutNoNewBatches
         expr: time() - latest_batch_timestamp{job="{{ include "blockscout-stack.fullname" . }}"{{- if .Values.blockscout.separateApi.enabled }},service="{{ include "blockscout-stack.fullname" . }}-blockscout-indexer-svc"{{- end }}} > {{ .Values.config.prometheus.rules.batchTimeMultiplier }}*batch_average_time{job="{{ include "blockscout-stack.fullname" . }}"{{- if .Values.blockscout.separateApi.enabled }},service="{{ include "blockscout-stack.fullname" . }}-blockscout-indexer-svc"{{- end }}}
         for: 5m
         labels:


### PR DESCRIPTION
The alert field should be a static identifier, not a templated value.

Per the [Prometheus alerting rules documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/), only label and annotation values support templating, not the alert name itself.

This causes the template syntax to appear literally in alert notifications instead of being evaluated.

For example:
```
• alertname: {{ $labels.job }} has no new batches
```

The dynamic information should be in the annotations where templating is properly supported.