### PR TITLE
feat(blockscout-stack): add Gateway API (HTTPRoute) support

### DIFF
--- a/charts/blockscout-stack/CHANGELOG.md
+++ b/charts/blockscout-stack/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ChangeLog
 
+## 4.4.0
+
+### Feature
+
+- Add Gateway API (HTTPRoute) support for blockscout, frontend, stats, and user-ops-indexer components
+- Gateway API can be used alongside or instead of traditional Ingress resources
+- Support for referencing existing Gateway resources with configurable hostnames and TLS
+
 ## 4.3.0
 
 ### Feature

--- a/charts/blockscout-stack/Chart.yaml
+++ b/charts/blockscout-stack/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.3.0
+version: 4.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/blockscout-stack/templates/blockscout-httproute.yaml
+++ b/charts/blockscout-stack/templates/blockscout-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.blockscout.enabled }}
+{{- if .Values.blockscout.gateway.enabled }}
+{{- $fullName := include "blockscout-stack.fullname" . -}}
+{{- $svcPort := .Values.blockscout.service.port -}}
+{{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-blockscout-httproute
+  labels:
+    {{- include "blockscout-stack.labels" . | nindent 4 }}
+  {{- with .Values.blockscout.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if and .Values.blockscout.gateway.gatewayRef.name .Values.blockscout.gateway.gatewayRef.namespace }}
+    - name: {{ .Values.blockscout.gateway.gatewayRef.name }}
+      namespace: {{ .Values.blockscout.gateway.gatewayRef.namespace }}
+    {{- else if .Values.blockscout.gateway.gatewayRef.name }}
+    - name: {{ .Values.blockscout.gateway.gatewayRef.name }}
+    {{- end }}
+  {{- if .Values.blockscout.gateway.hostnames }}
+  hostnames:
+    {{- range .Values.blockscout.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.blockscout.ingress.paths }}
+        - path:
+            {{- if eq .pathType "Exact" }}
+            type: PathExact
+            {{- else if eq .pathType "Prefix" }}
+            type: PathPrefix
+            {{- else }}
+            type: PathPrefix
+            {{- end }}
+            value: {{ .path | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-blockscout-svc
+          port: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/charts/blockscout-stack/templates/frontend-httproute.yaml
+++ b/charts/blockscout-stack/templates/frontend-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.frontend.enabled }}
+{{- if .Values.frontend.gateway.enabled }}
+{{- $fullName := include "blockscout-stack.fullname" . -}}
+{{- $svcPort := .Values.frontend.service.port -}}
+{{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-frontend-httproute
+  labels:
+    {{- include "blockscout-stack.labels" . | nindent 4 }}
+  {{- with .Values.frontend.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if and .Values.frontend.gateway.gatewayRef.name .Values.frontend.gateway.gatewayRef.namespace }}
+    - name: {{ .Values.frontend.gateway.gatewayRef.name }}
+      namespace: {{ .Values.frontend.gateway.gatewayRef.namespace }}
+    {{- else if .Values.frontend.gateway.gatewayRef.name }}
+    - name: {{ .Values.frontend.gateway.gatewayRef.name }}
+    {{- end }}
+  {{- if .Values.frontend.gateway.hostnames }}
+  hostnames:
+    {{- range .Values.frontend.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.frontend.ingress.paths }}
+        - path:
+            {{- if eq .pathType "Exact" }}
+            type: PathExact
+            {{- else if eq .pathType "Prefix" }}
+            type: PathPrefix
+            {{- else }}
+            type: PathPrefix
+            {{- end }}
+            value: {{ .path | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-frontend-svc
+          port: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/charts/blockscout-stack/templates/stats-httproute.yaml
+++ b/charts/blockscout-stack/templates/stats-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.stats.enabled }}
+{{- if .Values.stats.gateway.enabled }}
+{{- $fullName := include "blockscout-stack.fullname" . -}}
+{{- $svcPort := .Values.stats.service.port -}}
+{{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-stats-httproute
+  labels:
+    {{- include "blockscout-stack.labels" . | nindent 4 }}
+  {{- with .Values.stats.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if and .Values.stats.gateway.gatewayRef.name .Values.stats.gateway.gatewayRef.namespace }}
+    - name: {{ .Values.stats.gateway.gatewayRef.name }}
+      namespace: {{ .Values.stats.gateway.gatewayRef.namespace }}
+    {{- else if .Values.stats.gateway.gatewayRef.name }}
+    - name: {{ .Values.stats.gateway.gatewayRef.name }}
+    {{- end }}
+  {{- if .Values.stats.gateway.hostnames }}
+  hostnames:
+    {{- range .Values.stats.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.stats.ingress.paths }}
+        - path:
+            {{- if eq .pathType "Exact" }}
+            type: PathExact
+            {{- else if eq .pathType "Prefix" }}
+            type: PathPrefix
+            {{- else }}
+            type: PathPrefix
+            {{- end }}
+            value: {{ .path | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-stats-svc
+          port: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/charts/blockscout-stack/templates/user-ops-indexer-httproute.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-httproute.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.userOpsIndexer.enabled }}
+{{- if .Values.userOpsIndexer.gateway.enabled }}
+{{- $fullName := include "blockscout-stack.fullname" . -}}
+{{- $svcPort := .Values.userOpsIndexer.service.port -}}
+{{- if semverCompare ">=1.27-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: gateway.networking.k8s.io/v1
+{{- else -}}
+apiVersion: gateway.networking.k8s.io/v1beta1
+{{- end }}
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}-user-ops-indexer-httproute
+  labels:
+    {{- include "blockscout-stack.labels" . | nindent 4 }}
+  {{- with .Values.userOpsIndexer.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- if and .Values.userOpsIndexer.gateway.gatewayRef.name .Values.userOpsIndexer.gateway.gatewayRef.namespace }}
+    - name: {{ .Values.userOpsIndexer.gateway.gatewayRef.name }}
+      namespace: {{ .Values.userOpsIndexer.gateway.gatewayRef.namespace }}
+    {{- else if .Values.userOpsIndexer.gateway.gatewayRef.name }}
+    - name: {{ .Values.userOpsIndexer.gateway.gatewayRef.name }}
+    {{- end }}
+  {{- if .Values.userOpsIndexer.gateway.hostnames }}
+  hostnames:
+    {{- range .Values.userOpsIndexer.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        {{- range .Values.userOpsIndexer.ingress.paths }}
+        - path:
+            {{- if eq .pathType "Exact" }}
+            type: PathExact
+            {{- else if eq .pathType "Prefix" }}
+            type: PathPrefix
+            {{- else }}
+            type: PathPrefix
+            {{- end }}
+            value: {{ .path | quote }}
+        {{- end }}
+      backendRefs:
+        - name: {{ $fullName }}-user-ops-indexer-svc
+          port: {{ $svcPort }}
+{{- end }}
+{{- end }}

--- a/charts/blockscout-stack/values.yaml
+++ b/charts/blockscout-stack/values.yaml
@@ -48,6 +48,23 @@ config:
           }
       tls:
         enabled: true
+    ## Configure Gateway API HTTPRoute for redirect functionality
+    ##
+    gateway:
+      enabled: false
+      ## Reference to an existing Gateway resource
+      ##
+      gatewayRef:
+        name: ""
+        namespace: ""
+      ## TLS configuration for HTTPRoute
+      ##
+      tls:
+        enabled: false
+        certificateRefs: []
+      ## Custom annotations for HTTPRoute
+      ##
+      annotations: {}
   ## If set to true will create service monitors for blockscout and stats
   ##
   prometheus:
@@ -214,6 +231,29 @@ blockscout:
         pathType: Exact
       - path: /auth/logout
         pathType: Exact
+  ## Configure Gateway API HTTPRoute resource that allow you to access the blockscout installation.
+  ## ref: https://gateway-api.sigs.k8s.io/
+  ## Note: When enabled, gatewayRef.name is required. If namespace is not specified, it defaults to the same namespace as the HTTPRoute.
+  ##
+    gateway:
+      enabled: false
+      ## Reference to an existing Gateway resource (required when gateway.enabled is true)
+    ##
+    gatewayRef:
+      name: ""
+      namespace: ""
+    hostnames: []
+      # - blockscout.example.com
+    ## TLS configuration for HTTPRoute
+    ##
+    tls:
+      enabled: false
+      certificateRefs: []
+        # - name: blockscout-tls-cert
+        #   kind: Secret
+    ## Custom annotations for HTTPRoute
+    ##
+    annotations: {}
 
   resources:
     limits:
@@ -273,6 +313,29 @@ frontend:
       #secretName:
     paths:
       - path: /
+  ## Configure Gateway API HTTPRoute resource that allow you to access the frontend installation.
+  ## ref: https://gateway-api.sigs.k8s.io/
+  ## Note: When enabled, gatewayRef.name is required. If namespace is not specified, it defaults to the same namespace as the HTTPRoute.
+  ##
+    gateway:
+      enabled: false
+      ## Reference to an existing Gateway resource (required when gateway.enabled is true)
+    ##
+    gatewayRef:
+      name: ""
+      namespace: ""
+    hostnames: []
+      # - explorer.example.com
+    ## TLS configuration for HTTPRoute
+    ##
+    tls:
+      enabled: false
+      certificateRefs: []
+        # - name: frontend-tls-cert
+        #   kind: Secret
+    ## Custom annotations for HTTPRoute
+    ##
+    annotations: {}
 
   resources:
     limits:
@@ -361,6 +424,29 @@ stats:
     paths:
       - path: /
         pathType: Prefix
+  ## Configure Gateway API HTTPRoute resource that allow you to access the stats installation.
+  ## ref: https://gateway-api.sigs.k8s.io/
+  ## Note: When enabled, gatewayRef.name is required. If namespace is not specified, it defaults to the same namespace as the HTTPRoute.
+  ##
+    gateway:
+      enabled: false
+      ## Reference to an existing Gateway resource (required when gateway.enabled is true)
+    ##
+    gatewayRef:
+      name: ""
+      namespace: ""
+    hostnames: []
+      # - stats.example.com
+    ## TLS configuration for HTTPRoute
+    ##
+    tls:
+      enabled: false
+      certificateRefs: []
+        # - name: stats-tls-cert
+        #   kind: Secret
+    ## Custom annotations for HTTPRoute
+    ##
+    annotations: {}
 
   resources:
     limits:
@@ -450,6 +536,29 @@ userOpsIndexer:
     paths:
       - path: /
         pathType: Prefix
+  ## Configure Gateway API HTTPRoute resource that allow you to access the user-ops-indexer installation.
+  ## ref: https://gateway-api.sigs.k8s.io/
+  ## Note: When enabled, gatewayRef.name is required. If namespace is not specified, it defaults to the same namespace as the HTTPRoute.
+  ##
+    gateway:
+      enabled: false
+      ## Reference to an existing Gateway resource (required when gateway.enabled is true)
+    ##
+    gatewayRef:
+      name: ""
+      namespace: ""
+    hostnames: []
+      # - userops.example.com
+    ## TLS configuration for HTTPRoute
+    ##
+    tls:
+      enabled: false
+      certificateRefs: []
+        # - name: userops-tls-cert
+        #   kind: Secret
+    ## Custom annotations for HTTPRoute
+    ##
+    annotations: {}
 
   resources:
     limits:


### PR DESCRIPTION
This PR adds support for Gateway API (HTTPRoute) resources to the blockscout-stack Helm chart, allowing users to use Gateway API as an alternative to or alongside traditional Kubernetes Ingress resources.

Closes https://github.com/blockscout/helm-charts/issues/106

## Changes

- Added `gateway` configuration sections to `values.yaml` for blockscout, frontend, stats, and user-ops-indexer components
- Created HTTPRoute templates: `blockscout-httproute.yaml`, `frontend-httproute.yaml`, `stats-httproute.yaml`, `user-ops-indexer-httproute.yaml`
- Support for Gateway API v1beta1 (and v1 for Kubernetes 1.27+)
- Maps existing Ingress path configurations to HTTPRoute path matches
- Backward compatible - existing Ingress configurations continue to work unchanged
- Ingress and Gateway API can be enabled simultaneously

## Usage Example

```yaml
blockscout:
  gateway:
    enabled: true
    gatewayRef:
      name: my-gateway
      namespace: default
    hostnames:
      - blockscout.example.com
```

## Documentation

- Updated CHANGELOG.md with version 4.4.0 entry

## Testing 
I have tested this by exposing both the frontend and backend, and everything works as expected. Example:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  annotations:
    meta.helm.sh/release-name: blockscout
    meta.helm.sh/release-namespace: chain-alpha
  creationTimestamp: "2025-12-24T09:22:52Z"
  generation: 1
  labels:
    app.kubernetes.io/instance: blockscout
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: blockscout-stack
    app.kubernetes.io/version: 9.3.0
    helm.sh/chart: blockscout-stack-4.4.0
  name: blockscout-blockscout-httproute
  namespace: chain-alpha
  resourceVersion: "309600872"
  uid: 79fe4e41-77ca-48d4-8b61-d0bf261c296c
spec:
  hostnames:
  - blockscout.example.com
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: internal
    namespace: default
  rules:
  - backendRefs:
    - group: ""
      kind: Service
      name: blockscout-blockscout-svc
      port: 80
      weight: 1
    matches:
    - path:
        type: PathPrefix
        value: /
status:
  parents:
  - conditions:
    - lastTransitionTime: "2025-12-24T09:22:52Z"
      message: Route is accepted
      observedGeneration: 1
      reason: Accepted
      status: "True"
      type: Accepted
    - lastTransitionTime: "2025-12-24T09:22:52Z"
      message: Resolved all the Object references for the Route
      observedGeneration: 1
      reason: ResolvedRefs
      status: "True"
      type: ResolvedRefs
    controllerName: gateway.envoyproxy.io/gatewayclass-controller
    parentRef:
      group: gateway.networking.k8s.io
      kind: Gateway
      name: internal
      namespace: default
```