### PR TITLE
fix: add namespace to blockscout-stack + indexer image tag fix

### DIFF
--- a/charts/blockscout-stack/templates/blockscout-deployment.yaml
+++ b/charts/blockscout-stack/templates/blockscout-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-blockscout
     {{- include "blockscout-stack.labels" . | nindent 4 }}
@@ -266,6 +267,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-indexer
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-blockscout-indexer
     {{- include "blockscout-stack.labels" . | nindent 4 }}
@@ -301,7 +303,7 @@ spec:
         - name: {{ .Chart.Name }}-blockscout
           securityContext:
             {{- toYaml .Values.blockscout.securityContext | nindent 12 }}
-          image: "{{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}-indexer"
+          image: "{{ .Values.blockscout.image.repository }}:{{ .Values.blockscout.image.tag }}"
           resources:
             {{- toYaml .Values.blockscout.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.blockscout.image.pullPolicy }}

--- a/charts/blockscout-stack/templates/blockscout-ingress.yaml
+++ b/charts/blockscout-stack/templates/blockscout-ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-blockscout-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   {{- with .Values.blockscout.ingress.annotations }}

--- a/charts/blockscout-stack/templates/blockscout-migration-job.yaml
+++ b/charts/blockscout-stack/templates/blockscout-migration-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-migrations
+  namespace: {{ .Release.Namespace }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-5"

--- a/charts/blockscout-stack/templates/blockscout-prometheus-rules.yaml
+++ b/charts/blockscout-stack/templates/blockscout-prometheus-rules.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:

--- a/charts/blockscout-stack/templates/blockscout-secret.yaml
+++ b/charts/blockscout-stack/templates/blockscout-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-env
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blockscout-stack/templates/blockscout-service.yaml
+++ b/charts/blockscout-stack/templates/blockscout-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-blockscout-svc
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/blockscout-servicemonitor-blackbox.yaml
+++ b/charts/blockscout-stack/templates/blockscout-servicemonitor-blackbox.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-bb
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:

--- a/charts/blockscout-stack/templates/blockscout-servicemonitor.yaml
+++ b/charts/blockscout-stack/templates/blockscout-servicemonitor.yaml
@@ -4,6 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-blockscout-indexer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:

--- a/charts/blockscout-stack/templates/frontend-basic-auth-secret.yaml
+++ b/charts/blockscout-stack/templates/frontend-basic-auth-secret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blockscout-stack/templates/frontend-deployment.yaml
+++ b/charts/blockscout-stack/templates/frontend-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-frontend
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-frontend
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/frontend-ingress.yaml
+++ b/charts/blockscout-stack/templates/frontend-ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-frontend-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   {{- $annotations := dict }}

--- a/charts/blockscout-stack/templates/frontend-podmonitor.yaml
+++ b/charts/blockscout-stack/templates/frontend-podmonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-frontend-podmonitor
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:

--- a/charts/blockscout-stack/templates/frontend-secret.yaml
+++ b/charts/blockscout-stack/templates/frontend-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-frontend-env
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blockscout-stack/templates/frontend-service.yaml
+++ b/charts/blockscout-stack/templates/frontend-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-frontend-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-frontend-svc
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/redirect-ingress.yaml
+++ b/charts/blockscout-stack/templates/redirect-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-redirect-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   annotations:

--- a/charts/blockscout-stack/templates/serviceaccount.yaml
+++ b/charts/blockscout-stack/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "blockscout-stack.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/blockscout-stack/templates/stats-cm.yaml
+++ b/charts/blockscout-stack/templates/stats-cm.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-stats-cm
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 data:

--- a/charts/blockscout-stack/templates/stats-deployment.yaml
+++ b/charts/blockscout-stack/templates/stats-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-stats
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-stats
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/stats-ingress.yaml
+++ b/charts/blockscout-stack/templates/stats-ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-stats-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   {{- with .Values.stats.ingress.annotations }}

--- a/charts/blockscout-stack/templates/stats-secret.yaml
+++ b/charts/blockscout-stack/templates/stats-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-stats-env
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blockscout-stack/templates/stats-service.yaml
+++ b/charts/blockscout-stack/templates/stats-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-stats-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-stats-svc
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/stats-servicemonitor.yaml
+++ b/charts/blockscout-stack/templates/stats-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-stats
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:

--- a/charts/blockscout-stack/templates/user-ops-indexer-deployment.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/user-ops-indexer-ingress.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-user-ops-indexer-ingress
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
   {{- with .Values.userOpsIndexer.ingress.annotations }}

--- a/charts/blockscout-stack/templates/user-ops-indexer-secret.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer-env
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/blockscout-stack/templates/user-ops-indexer-service.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer-svc
     {{- include "blockscout-stack.labels" . | nindent 4 }}

--- a/charts/blockscout-stack/templates/user-ops-indexer-servicemonitor.yaml
+++ b/charts/blockscout-stack/templates/user-ops-indexer-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "blockscout-stack.fullname" . }}-user-ops-indexer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "blockscout-stack.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Adds namespace support via helm/kustomize's helm generator by `--namespace=<>` flag.
